### PR TITLE
Fix handling of mocha-tap-reporter generated output

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "prepublish": "npm run lint",
-    "test": "tape src/test/pass.js | cross-env bin/tap-junit --output output/test --name pass",
+    "test": "tape src/test/pass.js | cross-env bin/tap-junit --output output/test --name pass && cross-env bin/tap-junit --output output/test --name nontape.xml < src/test/non-tape.tap",
     "test:nooutput": "tape src/test/fail.js | cross-env bin/tap-junit",
     "test:fail": "tape src/test/fail.js | cross-env bin/tap-junit --output output/test",
     "lint": "eslint src/*.js"

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const setOutput = (loc) => {
 const tapJunit = () => {
 	let out = through();
 	let testSuites = [];
-	let testCase = {};
+	let testCase = null;
 	const tap = parser();
 	const dup = duplexer(tap, out);
 

--- a/src/test/non-tape.tap
+++ b/src/test/non-tape.tap
@@ -1,0 +1,6 @@
+1..2
+ok 1 testFoo.js - Do stuff with stuff
+ok 2 testFoo.js - Do more stuff
+# tests 2
+# pass 2
+# fail 0


### PR DESCRIPTION
It seems that lazy initialization of `testCase` currently uses `if (!testCase) { ... }` comparison. Because it is initialized to empty object (`{}`) this check will always fail.

This triggers at least with [mocha-tap-reporter](https://github.com/lyroyce/mocha-tap-reporter) output. Based on testing it seems that the output never triggers `test` event from `tap-out`, and this causes the `assert` event to operate on basically uninitialized `testCase`. This results following error:

```
TypeError: Cannot read property 'push' of undefined
    at PassThrough.tap.on.res (/Users/hsalokor/src/github/tap-junit/src/index.js:116:19)
    at emitOne (events.js:96:13)
    at PassThrough.emit (events.js:188:7)
```

Pull request adds a test and contains a fix (initialize `testCase` to `null`).