### PR TITLE
Relax filename sanitation to allow - and _ and report correct output filename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ const tapJunit = () => {
 
 	const sanitizeString = (str) => {
 		if (str) {
-			return str.replace(/\W/g, '').trim();
+			return str.replace(/[^\w-_]/g, '').trim();
 		}
 
 		return str;

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ const tapJunit = () => {
 					console.error('There was a write error when tap-junit tried to write your output file', xmlErr);
 					process.exitCode = 1;
 				}
-				process.stdout.write(`Finished! tap.xml created at: ${output}${EOL}`);
+				process.stdout.write(`Finished! ${name}.xml created at: ${output}${EOL}`);
 				if (!passing) {
 					console.error(new Error('Looks like some test suites failed'));
 					process.exitCode = 1;


### PR DESCRIPTION
I noticed that the `--name` sanitation is a bit overeager, and it also removes commonly used separators such as `-` and `_`.

Additionally, output is always reported as `tap.xml` in program output, even if it is overridden by `--name`. This is mostly a cosmetic issue, but may be a bit confusing.

This pull request fixes both minor issues.