### PR TITLE
Fixes for new suite initialization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ const tapJunit = () => {
 	// Event for each assert inside the current Test
 	tap.on('assert', res => {
 		if (!testCase) {
-			testCase = newTest('Default');
+			testCase = newTest({ name: 'Default' });
 		}
 		testCase.assertCount++;
 		res.skip = isSkipped(res);

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ const tapJunit = () => {
 
 		return str;
 	};
+	const name = sanitizeString(parsedArgs.name) || 'tap';
 
 	/**
 	 * Writes the tap.xml file
@@ -43,7 +44,6 @@ const tapJunit = () => {
 	 */
 	const writeOutput = (xml, passing) => {
 		const output = parsedArgs.output || process.cwd();
-		const name = sanitizeString(parsedArgs.name) || 'tap';
 
 		fse.mkdirp(output, err => {
 			if (err) {
@@ -69,7 +69,7 @@ const tapJunit = () => {
 	 * @param  {String} testInfo Test name
 	 * @return {Object}            Returns the newly created test object
 	 */
-	const newTest = ({name, number}) => {
+	const newTest = ({testName, number}) => {
 		const recordedTest = {
 			id: number,
 			assertCount: 0,
@@ -81,7 +81,7 @@ const tapJunit = () => {
 			errors: [],
 			failCount: 0,
 			failAsserts: [],
-			testName: name
+			testName
 		};
 
 		testSuites.push(recordedTest);
@@ -107,7 +107,7 @@ const tapJunit = () => {
 	// Event for each assert inside the current Test
 	tap.on('assert', res => {
 		if (!testCase) {
-			testCase = newTest({ name: 'Default' });
+			testCase = newTest({ name });
 		}
 		testCase.assertCount++;
 		res.skip = isSkipped(res);

--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,9 @@ const tapJunit = () => {
 
 	// Someone used a console.log or t.comment in their tests
 	tap.on('comment', () => {
+		if (!testCase) {
+			testCase = newTest({ name });
+		}
 		testCase.comments++;
 	});
 

--- a/src/test/non-tape.tap
+++ b/src/test/non-tape.tap
@@ -1,4 +1,5 @@
 1..2
+leaking comment from test initialization
 ok 1 testFoo.js - Do stuff with stuff
 ok 2 testFoo.js - Do more stuff
 # tests 2


### PR DESCRIPTION
I noticed couple of corner cases with our data:

* The testcase lazy initialization does not pass the test suite name properly to constructor function. This leads to issue where test suite name is initialized to empty string, and this confuses Jenkins testcase display
* If test prints debugging output before first tap entry is created, the `testCase` object is accessed without being initialized
* The test suite name passed from command line is not passed to `newTest` initialization

This pull request adds a test for the debugging print issue, and fixes all above errors.