### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Silly small, silly easy junit output formatter for tap.
 
 Works with tape and other tap based tests just pipe it into tap-junit
 
-**This README reflects the development branch, which is under the beta tag for tap-junit**
-
 ## Changelog
 
 You can checkout the changelog at: https://github.com/dhershman1/tap-junit/blob/master/changelog.md

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.1
+
+- Fixed Readme typo
+
 ## v3.0.0
 
 ### POSSIBLE BREAKING CHANGES

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-junit",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-junit",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Silly small, silly easy junit output formatter for tap.",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
There was a message in the readme that was no longer relevant. 
