### PR TITLE
Feature/#24 specify ext name

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,6 +17,8 @@ IF you are editing exsiting functionality please ensure all unit tests remain pa
 ## Developing
 
 - Please stick to the [standardjs](https://standardjs.com/) style for development
+- This lib is written using ES6 please keep all changes to this version
+  - This excludes the import/export since node does not support it internally yet
 - Make sure all current and new units tests are fully passing
 - Please try to keep the flow consistent to what is already present
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-# VERSION NUMBER
-
 Please give a light description of your changes here
 
 ## Breaking Changes

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ tape tests/thing.js | tap-junit > output/thing.xml
 tap-junit -i tap.txt -s suite-name
 ```
 
+You can now use custom extensions (in version 3.1.0+) simply add the extension to the end of your file name. If none is provided `tap-junit` will still default to `.xml`
+
+`tape test/*.js | tap-junit -o output/tests -n tape.xuni`
+
+The above will create a file called `tape.xuni` in the `output/tests` directory with the results inside.
+
 ## Output
 
 ```xml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-junit",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepack": "npm run lint",
     "clear": "rimraf output/**",
     "test": "tape tests/pass.js | cross-env bin/tap-junit -o output/test -n pass -s suite-name",
-    "test:input": "cross-env bin/tap-junit --output output --name api --suite api-test --input tests/non-tape.tap",
+    "test:input": "cross-env bin/tap-junit --output output --name api.xuni --suite api-test --input tests/non-tape.tap",
     "test:zero": "tape tests/pass.js | cross-env bin/tap-junit > output/pass-zero.xml",
     "test:nontape": "cross-env bin/tap-junit --output output/test --name nontape.xml < tests/non-tape.tap",
     "test:nooutput": "tape tests/pass.js | cross-env bin/tap-junit",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-junit",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Silly small, silly easy junit output formatter for tap.",
   "main": "src/index.js",
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 /* Modules */
 const { EOL } = require('os')
+const path = require('path')
 const parser = require('tap-out')
 
 const serialize = require('./serialize')
@@ -7,17 +8,21 @@ const write = require('./write')
 
 const tapJunit = args => {
   let testCase = null
+  // Keep track of custom extensions
+  let extension = '.xml'
   const testSuites = []
   const tap = parser()
 
   /* Helpers */
   const sanitizeString = (str = 'tap') => {
+    const { name, ext } = path.parse(str)
     // In case the user included .xml in the name argument lets get rid of it
-    if (str.includes('.xml')) {
-      return str.replace('.xml', '').replace(/[^\w-_]/g, '').trim()
+
+    if (ext) {
+      extension = ext
     }
 
-    return str.replace(/[^\w-_]/g, '').trim()
+    return name.replace(/[^\w-_]/g, '').trim()
   }
 
   /**
@@ -27,7 +32,7 @@ const tapJunit = args => {
    */
   const writeOutput = (xml, passing) => {
     const name = sanitizeString(args.name)
-    const fileName = `${name}.xml`
+    const fileName = `${name}${extension}`
 
     write(args.output, fileName, xml)
       .then(() => {


### PR DESCRIPTION
Adding in custom extension support requested by #24 

## New

- You can now use custom extensions, just apply then to your file name in the `-n` option
  - Example: `tape test/*.js | tap-junit -o output/tests -n tape.xuni`
  - If no extension is provided `tap-junit` will default to `.xml` automatically

## Improved

- Slight tweak to the contribution and PR template mark down files
