### PR TITLE
Development to v4.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report to help tap-junit improve
 
 ---
 
@@ -16,6 +16,12 @@ Steps to reproduce the behavior:
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
+
+**Command Line Usage**
+If you're able please specify the command line format you used for tap-junit for example:
+```cli
+tap-junit -o output -n dependencies.xml -i tests/j-tap.tap
+```
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You can checkout the changelog at: https://github.com/dhershman1/tap-junit/blob/
 
 ## Parameters
 
+- `-c, --classname` - The name you want to apply to the `testsuite` element (if not set no name is given to the output testsuite)
 - `-o, --output` - designate where you want the .xml results to output
   - If you do not specify an output then results will be displayed within the terminal
 - `-n, --name` - value provided will be the name of the `output.xml` file, otherwise defaults to `tap.xml`

--- a/bin/tap-junit
+++ b/bin/tap-junit
@@ -3,6 +3,7 @@
 /* Modules */
 const parsedArgs = require('minimist')(process.argv.slice(2), {
   alias: {
+    c: 'classname',
     o: 'output',
     n: 'name',
     s: 'suite',

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v4.1.0
+
+### New
+
+- Added the `-c` argument which sets the `testsuite` (NOT `testsuites`) name
+  - This should fix [#32](https://github.com/dhershman1/tap-junit/issues/32) for the jenkins plugin it uses
+
+### Improved
+
+- Tweaked the github bug report template a little to ask for the CLI use of tap-junit
+
+### Fixed
+
+- Removed the old `xmlbuilder` dependency, woops
+
 ## v4.0.0
 
 ### BREAKING CHANGES

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-junit",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2975,11 +2975,6 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
-    },
-    "xmlbuilder": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.0.tgz",
-      "integrity": "sha512-xae5hmPQnmSFhpiuV3NGXq+FWGOvWy/rIzxVLnRtSSABbPZWltTQCe6WlHDpCq5pGvnGwNsWnS1FdkW7Tx9FNQ=="
     },
     "xmlbuilder2": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-junit",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Silly small, silly easy junit output formatter for tap.",
   "main": "src/index.js",
   "bin": {
@@ -15,6 +15,7 @@
     "test:nontape": "cross-env bin/tap-junit --output output/test --name nontape.xml < tests/non-tape.tap",
     "test:nooutput": "tape tests/pass.js | cross-env bin/tap-junit",
     "test:skip": "tape tests/skip.js | bin/tap-junit -o output/test -n skip",
+    "test:jtap": "bin/tap-junit -o output -n dependencies.xml -i tests/j-tap.tap -c jenkins-deps",
     "tape": "tape tests/pass.js",
     "tapx": "bin/tap-junit -i tests/tapX.tap -o output/test -n tapx",
     "bat": "bin/tap-junit -i tests/bats-1.0.0.txt -o output/test -n bat -p",
@@ -47,7 +48,6 @@
   "dependencies": {
     "minimist": "1.2.5",
     "tap-parser": "10.1.0",
-    "xmlbuilder": "15.1.0",
     "xmlbuilder2": "2.4.0"
   },
   "devDependencies": {

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -58,7 +58,7 @@ function buildFailureParams (fail, comment) {
   return failObj
 }
 
-module.exports = (testCases, output, comments, { name = 'Tap-Junit', pretty }) => {
+module.exports = (testCases, output, comments, { name = 'Tap-Junit', pretty, classname = 'Tap-Junit-Suite' }) => {
   const len = testCases.length
   const xmlObj = {
     testsuites: {
@@ -66,6 +66,7 @@ module.exports = (testCases, output, comments, { name = 'Tap-Junit', pretty }) =
       '@name': name,
       '@failures': output.fail,
       testsuite: {
+        '@name': classname,
         '@tests': output.count,
         '@skipped': output.skip,
         '@failures': output.fail,

--- a/tests/j-tap.tap
+++ b/tests/j-tap.tap
@@ -1,0 +1,9 @@
+TAP version 13
+# @scope/package
+ok 1 - Package @scope/package is using registered runtime dependency @angular/core
+ok 2 - Package @scope/package is using registered runtime dependency @angular/cdk
+ok 3 - Package @scope/package is using registered runtime dependency rxjs
+ok 4 - Package @scope/package's dependency @angular/cdk is used
+ok 5 - Package @scope/package's dependency @angular/core is used
+ok 6 - Package @scope/package's dependency rxjs is used
+1..6


### PR DESCRIPTION
## New

- Added the `-c` argument which sets the `testsuite` (NOT `testsuites`) name
  - This should fix #32 for the jenkins plugin it uses

## Improved

- Tweaked the github bug report template a little to ask for the CLI use of tap-junit

## Fixed

- Removed the old `xmlbuilder` dependency, woops

